### PR TITLE
Add table for recourse methods and framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Find extensive documentation [here](https://carla-counterfactual-and-recourse-li
 - **ANN**: Artificial Neural Network with 2 hidden layers and ReLU activation function
 - **LR**: Linear Model with no hidden layer and no activation function
 
-### Which Recourse Methods work on which framework?
+### Which Recourse Methods work with which ML framework?
 The framework a counterfactual method currently works on is highly dependable on its implementation.
 We are working hard on it to make it independent. The latest state can be found here:
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Find extensive documentation [here](https://carla-counterfactual-and-recourse-li
 - **LR**: Linear Model with no hidden layer and no activation function
 
 ### Which Recourse Methods work with which ML framework?
-The framework a counterfactual method currently works on is highly dependable on its implementation.
+The framework a counterfactual method currently works with is dependent on its underlying implementation.
 We are working hard on it to make it independent. The latest state can be found here:
 
 | Recourse Method | Tensorflow | Pytorch |

--- a/README.md
+++ b/README.md
@@ -30,6 +30,23 @@ Find extensive documentation [here](https://carla-counterfactual-and-recourse-li
 - **ANN**: Artificial Neural Network with 2 hidden layers and ReLU activation function
 - **LR**: Linear Model with no hidden layer and no activation function
 
+### Which Recourse Methods work on which framework?
+The framework a counterfactual method currently works on is highly dependable on its implementation.
+We are working hard on it to make it independent. The latest state can be found here:
+
+| Recourse Method | Tensorflow | Pytorch |
+| --------------- | :--------: | :-----: |
+| Actionable Recourse | X | X |
+| CCHVAE |  | X |
+| CEM | X |  |
+| CLUE |  | X |
+| CRUDS |  | X |
+| DiCE | X | X |
+| FACE | X | X |
+| Growing Spheres | X | X |
+| Revise |  | X |
+| Wachter |  | X |
+
 ## Installation
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Find extensive documentation [here](https://carla-counterfactual-and-recourse-li
 
 ### Which Recourse Methods work with which ML framework?
 The framework a counterfactual method currently works with is dependent on its underlying implementation.
-We are working hard on it to make it independent. The latest state can be found here:
+It is planned to make all recourse methods available for all ML frameworks . The latest state can be found here:
 
 | Recourse Method | Tensorflow | Pytorch |
 | --------------- | :--------: | :-----: |

--- a/carla/recourse_methods/catalog/cchvae/model.py
+++ b/carla/recourse_methods/catalog/cchvae/model.py
@@ -20,14 +20,14 @@ from carla.recourse_methods.processing import (
 
 class CCHVAE(RecourseMethod):
     """
-    Implementation of CCHVAE [1]_.
+    Implementation of CCHVAE [1]_
 
     Parameters
     ----------
-    mlmodel: carla.model.MLModel
+    mlmodel : carla.model.MLModel
         Black-Box-Model
-    hyperparams: dict
-        Dictionary containing hyperparameters. See notes below for its contents.
+    hyperparams : dict
+        Dictionary containing hyperparameters. See Notes below to see its content.
 
     Methods
     -------
@@ -41,6 +41,7 @@ class CCHVAE(RecourseMethod):
     - Hyperparams
         Hyperparameter contains important information for the recourse method to initialize.
         Please make sure to pass all values as dict with the following keys.
+
         * "data_name": str
             name of the dataset
         * "n_search_samples": int, default: 300
@@ -57,6 +58,7 @@ class CCHVAE(RecourseMethod):
             If true, the encoding of x is done by drop_if_binary.
         * "vae_params": Dict
             With parameter for VAE.
+
             + "layers": list
                 List with number of neurons per layer.
             + "train": bool, default: True

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,6 +33,34 @@ Provided Machine Learning Models
 - **ANN**: Artificial Neural Network with 2 hidden layers and ReLU activation function
 - **LR**: Linear Model with no hidden layer and no activation function
 
+Which Recourse Methods work on which framework?
+-----------------------------------------------
+The framework a counterfactual method currently works on is highly dependable on its implementation.
+We are working hard on it to make it independent. The latest state can be found here:
+
++-----------------+------------+---------+
+| Recourse Method | Tensorflow | Pytorch |
++=================+============+=========+
+| AR              |     X      |    X    |
++-----------------+------------+---------+
+| CCHVAE          |            |    X    |
++-----------------+------------+---------+
+| CEM             |     X      |         |
++-----------------+------------+---------+
+| CLUE            |            |    X    |
++-----------------+------------+---------+
+| CRUDS           |            |    X    |
++-----------------+------------+---------+
+| DiCE            |     X      |    X    |
++-----------------+------------+---------+
+| FACE            |     X      |    X    |
++-----------------+------------+---------+
+| Growing Spheres |     X      |    X    |
++-----------------+------------+---------+
+| Revise          |            |    X    |
++-----------------+------------+---------+
+| Wachter         |            |    X    |
++-----------------+------------+---------+
 
 .. toctree::
    :maxdepth: 2
@@ -45,8 +73,6 @@ Provided Machine Learning Models
    recourse
    benchmarking
    license
-
-
 
 Indices and tables
 ==================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,9 +33,9 @@ Provided Machine Learning Models
 - **ANN**: Artificial Neural Network with 2 hidden layers and ReLU activation function
 - **LR**: Linear Model with no hidden layer and no activation function
 
-Which Recourse Methods work on which framework?
+Which Recourse Methods work with which ML framework?
 -----------------------------------------------
-The framework a counterfactual method currently works on is highly dependable on its implementation.
+The framework a counterfactual method currently works with is dependent on its underlying implementation.
 It is planned to make all recourse methods available for all ML frameworks. The latest state can be found here:
 
 +-----------------+------------+---------+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,7 +36,7 @@ Provided Machine Learning Models
 Which Recourse Methods work on which framework?
 -----------------------------------------------
 The framework a counterfactual method currently works on is highly dependable on its implementation.
-We are working hard on it to make it independent. The latest state can be found here:
+It is planned to make all recourse methods available for all ML frameworks. The latest state can be found here:
 
 +-----------------+------------+---------+
 | Recourse Method | Tensorflow | Pytorch |


### PR DESCRIPTION
This table would it make easier for users to find out which recourse method works currently with which framework.